### PR TITLE
Adding support for using SplunkToken in addition to username and password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ SPLUNK_HOST=your_splunk_host
 SPLUNK_PORT=8089
 SPLUNK_USERNAME=your_username
 SPLUNK_PASSWORD=your_password
+# Instead of username and password, you can use a token
+SPLUNK_TOKEN=your_splunk_token
 SPLUNK_SCHEME=https
 
 # FastMCP Settings

--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ VERIFY_SSL=true
 FASTMCP_LOG_LEVEL=INFO
 ```
 
+If tokens is used for credentials instead: 
+```env
+SPLUNK_HOST=your_splunk_host
+SPLUNK_PORT=8089
+SPLUNK_TOKEN=your_splunk_token
+SPLUNK_SCHEME=https
+VERIFY_SSL=true
+FASTMCP_LOG_LEVEL=INFO
+```
+
+
 ### Option 2: Docker Installation
 
 1. Pull the latest image:


### PR DESCRIPTION
- If `SPLUNK_TOKEN` is provided, then this will be used instead of username and password
- Use encoding to ensure that logging on Windows works with emoticons
- Added `SPLUNK_TOKEN` to env.example

Fix for issue #7 