### PR TITLE
Fix token auth by removing Bearer prefix from Splunk client args

### DIFF
--- a/splunk_mcp.py
+++ b/splunk_mcp.py
@@ -311,7 +311,7 @@ def get_splunk_connection() -> splunklib.client.Service:
                 port=SPLUNK_PORT,
                 scheme=SPLUNK_SCHEME,
                 verify=VERIFY_SSL,
-                token=f"Bearer {SPLUNK_TOKEN}"
+                token=SPLUNK_TOKEN
             )
         else:
             username = os.environ.get("SPLUNK_USERNAME", "admin")

--- a/splunk_mcp.py
+++ b/splunk_mcp.py
@@ -311,7 +311,7 @@ def get_splunk_connection() -> splunklib.client.Service:
                 port=SPLUNK_PORT,
                 scheme=SPLUNK_SCHEME,
                 verify=VERIFY_SSL,
-                token=SPLUNK_TOKEN
+                splunkToken=SPLUNK_TOKEN
             )
         else:
             username = os.environ.get("SPLUNK_USERNAME", "admin")

--- a/tests/test_endpoints_pytest.py
+++ b/tests/test_endpoints_pytest.py
@@ -476,6 +476,6 @@ async def test_splunk_token_auth():
             call_kwargs = mock_connect.call_args[1]
             assert call_kwargs["host"] == "token-host"
             assert str(call_kwargs["port"]) == "9999"
-            assert call_kwargs["token"] == "test-token"
+            assert call_kwargs["splunkToken"] == "test-token"
             assert "username" not in call_kwargs
             assert "password" not in call_kwargs 

--- a/tests/test_endpoints_pytest.py
+++ b/tests/test_endpoints_pytest.py
@@ -476,6 +476,6 @@ async def test_splunk_token_auth():
             call_kwargs = mock_connect.call_args[1]
             assert call_kwargs["host"] == "token-host"
             assert str(call_kwargs["port"]) == "9999"
-            assert call_kwargs["token"] == "Bearer test-token"
+            assert call_kwargs["token"] == "test-token"
             assert "username" not in call_kwargs
             assert "password" not in call_kwargs 


### PR DESCRIPTION
The current format of the request for token auth isn't correct; the Splunk SDK automatically adds the `Bearer` prefix to the auth header.

Symptom; MCP server fails to authenticate even if creds are correct:

```
INFO:     127.0.0.1:62491 - "POST /messages/?session_id= HTTP/1.1" 202 Accepted
2025-09-20 13:57:39,066 - mcp.server.lowlevel.server - INFO - Processing request of type CallToolRequest
2025-09-20 13:57:39,068 - __main__ - INFO -  Performing health check...
2025-09-20 13:57:39,173 - __main__ - ERROR - X Health check failed: Request failed: Session is not logged in.
```

Fix:

Changing `f"Bearer {SPLUNK_TOKEN}"` to just `SPLUNK_TOKEN` fixes the auth flow. I also updated the reference in the test file to not prefix `Bearer`.

The commits in #51 also do the same thing, but I figured I'd submit a pull request directly because `Bearer` is already in the `main` branch.

I also changed `token` to `splunkToken` which aligns more to the SDK [documentation](https://github.com/splunk/splunk-sdk-python/blob/b69baafc2583b3f6697b4fcb5a1f77903c586b87/README.md?plain=1#L67). (Interestingly, both `token` and `splunkToken` work for me even though `token` is supposed to be for session keys, so perhaps they are interchangeable)