### PR TITLE
fix: remove Bearer from token arg because connect call already includ…

### DIFF
--- a/splunk_mcp.py
+++ b/splunk_mcp.py
@@ -311,7 +311,7 @@ def get_splunk_connection() -> splunklib.client.Service:
                 port=SPLUNK_PORT,
                 scheme=SPLUNK_SCHEME,
                 verify=VERIFY_SSL,
-                token=f"Bearer {SPLUNK_TOKEN}"
+                token=SPLUNK_TOKEN
             )
         else:
             username = os.environ.get("SPLUNK_USERNAME", "admin")


### PR DESCRIPTION
…es it.

Token authentication doesn't work because "Bearer" is duplicated.